### PR TITLE
update maintainers

### DIFF
--- a/charts/helix/Chart.yaml
+++ b/charts/helix/Chart.yaml
@@ -6,6 +6,6 @@ type: application
 version: 0.1.0
 appVersion: "0.1.0"
 maintainers:
-- name: Samuel Attwood
-  url: https://github.com/samuelattwood
-  email: sam@synadia.com
+- name: Synadia
+  url: https://github.com/ConnectEverything
+  email: info@synadia.com


### PR DESCRIPTION
Update maintainers to list only Synadia

Contributors can of course still be found on GitHub