### PR TITLE
[control plane] dataPvc -> encryptionPvc

### DIFF
--- a/.github/workflows/control-plane-docs-sync.yaml
+++ b/.github/workflows/control-plane-docs-sync.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
     - main
-    - control-plane
     paths:
     - charts/control-plane/README.md
     - .github/workflows/control-plane-docs-sync.yaml

--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
 # helm-charts
 
 Helm Charts for Synadia Software
+
+```bash
+# add the synadia repo (only needs to be run once)
+helm repo add synadia https://connecteverything.github.io/helm-charts
+
+# update the synadia repo index (run to get updated chart versions)
+helm repo update synadia
+
+# list available charts in the synadia repo
+helm search repo synadia
+```

--- a/charts/control-plane/Chart.yaml
+++ b/charts/control-plane/Chart.yaml
@@ -3,7 +3,7 @@ name: control-plane
 description: Synadia Control Plane
 home: https://www.synadia.com/
 type: application
-version: 0.2.0-rc.0
+version: 0.2.0-rc.1
 appVersion: 0.2.0-rc.0
 maintainers:
 - name: Synadia

--- a/charts/control-plane/README.md
+++ b/charts/control-plane/README.md
@@ -1,12 +1,76 @@
-# Synadia Control Plane
+# Synadia Control Plane Helm Chart
 
-## Config Generation
+**Accessing the Helm Chart**
 
-The [config generation script](https://github.com/ConnectEverything/control-plane-beta#config-generation) can do much of the heavy lifting to populate values for your Synadia Control Plane deployment.
+```bash
+# add the synadia repo (only needs to be run once)
+helm repo add synadia https://connecteverything.github.io/helm-charts
 
-### Chart Values
+# update the synadia repo index (run to get updated chart versions)
+helm repo update synadia
 
-Details in [values.yaml](values.yaml)
+# now you can install the synadia/control-plane chart
+# note: you will need to configure image pull secrets for this to work
+helm upgrade --install control-plane synadia/control-plane
+```
+
+**Useful Tools and References:**
+
+- [Config Generation Script](https://github.com/ConnectEverything/control-plane-beta#config-generation) - can do much of the heavy lifting to populate values for your Synadia Control Plane deployment
+- [Chart Values file](https://github.com/ConnectEverything/helm-charts/blob/main/charts/control-plane/values.yaml) - lists all possible configuration options
+- Login Details - On first run, the `admin` user's credentials will be printed to the logs here:
+  ```bash
+  kubectl logs -c syn-cp deployment/control-plane
+  ```
+
+## Common Configuration
+
+### Image Pull Secret
+
+By default, you must add an Image Pull Secret that allows you to pull the Control Plane image:
+
+```yaml
+imagePullSecret:
+  username: my-user
+  password: my-password
+```
+
+### Configuring NATS Systems
+
+NATS Systems are JWT-operator enabled NATS Clusters that you want to manage using Control Plane.  The System URL, A System Account User Creds file, and an Operator Signing key are all required.
+
+```yaml
+config:
+  systems:
+    # key is the Name of the System, once it is deployed the Name here should not be changed
+    MySystem:
+      url: nats://demo.nats.io
+      systemUserCreds:
+        contents: |
+          paste system account user creds file contents here
+      operatorSigningKey:
+        contents: |
+          paste operator signing key here
+```
+
+### Exposing Control Plane via Ingress
+
+Control Plane web server can optionally be exposed via HTTP(S) using an Ingress.
+
+```yaml
+config:
+  server:
+    url: https://cp.nats.io
+
+ingress:
+  enabled: true
+  className: nginx
+  hosts:
+  - host: cp.nats.io
+  tlsSecretName: ingress-tls
+```
+
+### Full Example
 
 ### Example
 
@@ -46,24 +110,58 @@ config:
           paste operator signing key here
 ```
 
-### Deploy the Helm Chart
+**Deploy**
 
 ```bash
-helm repo add synadia https://connecteverything.github.io/helm-charts
-helm repo update
-helm upgrade --install control-plane -n syn-cp --create-namespace -f values.yaml -f values-secrets.yaml synadia/control-plane
+helm upgrade \
+  --install \
+  -f values.yaml \
+  -f values-secrets.yaml \
+  control-plane \
+  synadia/control-plane
 ```
 
-### Login Details
+## Deployment Modes
 
-On first run, login credentials will be visible in the logs
+### Single Replica Deployment
 
-```bash
-kubectl logs -n syn-cp deployment/control-plane
-```
+By default, the Control Plane deployment is a 1-replica Deployment that will create 3 Persistent Volume Claims.
 
-### Uninstall Chart and Purge Data
+1. 1GiB PVC mounted at `/data/encryption` - stores the auto-generated KMS key.
+   This PVC is not needed if `config.kms.key` is configured.
+2. 10GiB PVC mounted at `/data/postgres` - stores the internal PostgreSQL Database data.
+   This PVC is not needed if an external PostgreSQL Database at `config.dataSources.postgres` is configured.
+3. 10GiB PVC mounted at `/data/prometheus` - stores the internal Prometheus Server data.
+   This PVC is not needed if an external Prometheus Server at `config.dataSources.prometheus` is configured.
 
-```bash
-helm uninstall -n syn-cp control-plane
+### HA Deployment
+
+Requirements for an HA Deployment:
+
+1. KMS Key URL.  URLs for KMS integrations are documented on the [GoCloud Secrets](https://gocloud.dev/howto/secrets/) website. 
+   This script will generate a random base64 key, which can be used as the KMS Key URL:
+   ```bash
+   echo "base64key://$(head -c 32 /dev/urandom | base64)"
+   ```
+2. External PostgreSQL Database
+3. External Prometheus Server
+
+Example Configuration:
+
+```yaml
+config:
+  kms:
+    key:
+      url: your KMS Key URL
+  dataSources:
+    postgres:
+      dsn: your PostgreSQL DSN
+    prometheus:
+      url: your Prometheus URL
+
+deployment:
+  replicas: 2
+
+singleReplicaMode:
+  enabled: false
 ```

--- a/charts/control-plane/files/deployment/pod-template.yaml
+++ b/charts/control-plane/files/deployment/pod-template.yaml
@@ -45,27 +45,33 @@ spec:
   - name: config
     secret:
       secretName: {{ .Values.configSecret.name }}
-  # PVCs
-  {{- with .Values.singleReplicaMode }}
-  # data is either a PVC or an emptyDir
+  # data emptyDir
   - name: data
-    {{- if and .enabled .dataPvc.enabled }}
-    persistentVolumeClaim:
-      claimName: {{ .dataPvc.name | quote }}
-    {{- else }}
     emptyDir: {}
-    {{- end }}
-  {{- if and .enabled .postgresPvc.enabled }}
-  # postgres only enabled in singleReplicaMode
+  # Single Replica Mode PVCs
+  {{- with .Values.singleReplicaMode }}
+  {{- if .enabled }}
+  {{- with .encryptionPvc }}
+  {{- if .enabled }}
+  - name: encryption
+    persistentVolumeClaim:
+      claimName: {{ .name | quote }}
+  {{- end }}
+  {{- end }}
+  {{- with .postgresPvc }}
+  {{- if .enabled }}
   - name: postgres
     persistentVolumeClaim:
-      claimName: {{ .postgresPvc.name | quote }}
+      claimName: {{ .name | quote }}
   {{- end }}
-  {{- if and .enabled .prometheusPvc.enabled }}
-  # prometheus only enabled in singleReplicaMode
+  {{- end }}
+  {{- with .prometheusPvc }}
+  {{- if .enabled }}
   - name: prometheus
     persistentVolumeClaim:
-      claimName: {{ .prometheusPvc.name | quote }}
+      claimName: {{ .name | quote }}
+  {{- end }}
+  {{- end }}
   {{- end }}
   {{- end }}
   # contents secret

--- a/charts/control-plane/files/deployment/syn-cp-container.yaml
+++ b/charts/control-plane/files/deployment/syn-cp-container.yaml
@@ -25,20 +25,30 @@ volumeMounts:
 - name: config
   mountPath: /etc/syn-cp
 {{- $dataDir := trimSuffix "/" .config.data_dir }}
-# data PVC or emptyDir
+# data emptyDir
 - name: data
   mountPath: {{ $dataDir | quote }}
-# PVCs
+# Single Replica Mode PVCs
 {{- with .Values.singleReplicaMode }}
-{{- if and .enabled .postgresPvc.enabled }}
-# postgres only enabled in singleReplicaMode
+{{- if .enabled }}
+{{- with .encryptionPvc }}
+{{- if .enabled }}
+- name: encryption
+  mountPath: {{ printf "%s/encryption" $dataDir | quote}}
+{{- end }}
+{{- end }}
+{{- with .postgresPvc }}
+{{- if .enabled }}
 - name: postgres
   mountPath: {{ printf "%s/postgres" $dataDir | quote}}
 {{- end }}
-{{- if and .enabled .prometheusPvc.enabled }}
-# prometheus only enabled in singleReplicaMode
+{{- end }}
+{{- with .prometheusPvc }}
+{{- if .enabled }}
 - name: prometheus
   mountPath: {{ printf "%s/prometheus" $dataDir | quote}}
+{{- end }}
+{{- end }}
 {{- end }}
 {{- end }}
 # contents secret

--- a/charts/control-plane/templates/_helpers.tpl
+++ b/charts/control-plane/templates/_helpers.tpl
@@ -44,7 +44,7 @@ Set default values.
     {{- $_ := set .ingress                         "name" (.ingress.name                         | default $name) }}
     {{- $_ := set .service                         "name" (.service.name                         | default $name) }}
     {{- $_ := set .serviceAccount                  "name" (.serviceAccount.name                  | default $name) }}
-    {{- $_ := set .singleReplicaMode.dataPvc       "name" (.singleReplicaMode.dataPvc.name       | default (printf "%s-data" $name)) }}
+    {{- $_ := set .singleReplicaMode.encryptionPvc "name" (.singleReplicaMode.encryptionPvc.name | default (printf "%s-encryption" $name)) }}
     {{- $_ := set .singleReplicaMode.postgresPvc   "name" (.singleReplicaMode.postgresPvc.name   | default (printf "%s-postgres" $name)) }}
     {{- $_ := set .singleReplicaMode.prometheusPvc "name" (.singleReplicaMode.prometheusPvc.name | default (printf "%s-prometheus" $name)) }}
   {{- end }}

--- a/charts/control-plane/templates/single-replica-mode/data-pvc.yaml
+++ b/charts/control-plane/templates/single-replica-mode/data-pvc.yaml
@@ -1,7 +1,7 @@
 {{- include "scp.defaultValues" . }}
 {{- with .Values.singleReplicaMode }}
 {{- if .enabled }}
-{{- with .dataPvc }}
+{{- with .encryptionPvc }}
 {{- if .enabled }}
 {{- include "scp.loadMergePatch" (merge (dict "file" "pvc.yaml" "ctx" (merge (dict "pvc" .) $)) .) }}
 {{- end }}

--- a/charts/control-plane/test/chart_test.go
+++ b/charts/control-plane/test/chart_test.go
@@ -25,7 +25,7 @@ type Resources struct {
 	Ingress                        Resource[networkingv1.Ingress]
 	Service                        Resource[corev1.Service]
 	ServiceAccount                 Resource[corev1.ServiceAccount]
-	SingleReplicaModeDataPvc       Resource[corev1.PersistentVolumeClaim]
+	SingleReplicaModeEncryptionPvc Resource[corev1.PersistentVolumeClaim]
 	SingleReplicaModePostgresPvc   Resource[corev1.PersistentVolumeClaim]
 	SingleReplicaModePrometheusPvc Resource[corev1.PersistentVolumeClaim]
 	ExtraConfigMap                 Resource[corev1.ConfigMap]
@@ -42,7 +42,7 @@ func (r *Resources) Iter() []MutableResource {
 		r.Ingress.Mutable(),
 		r.Service.Mutable(),
 		r.ServiceAccount.Mutable(),
-		r.SingleReplicaModeDataPvc.Mutable(),
+		r.SingleReplicaModeEncryptionPvc.Mutable(),
 		r.SingleReplicaModePostgresPvc.Mutable(),
 		r.SingleReplicaModePrometheusPvc.Mutable(),
 		r.ExtraConfigMap.Mutable(),
@@ -105,8 +105,8 @@ func GenerateResources(fullName string) *Resources {
 		ServiceAccount: Resource[corev1.ServiceAccount]{
 			ID: "ServiceAccount/" + fullName,
 		},
-		SingleReplicaModeDataPvc: Resource[corev1.PersistentVolumeClaim]{
-			ID: "PersistentVolumeClaim/" + fullName + "-data",
+		SingleReplicaModeEncryptionPvc: Resource[corev1.PersistentVolumeClaim]{
+			ID: "PersistentVolumeClaim/" + fullName + "-encryption",
 		},
 		SingleReplicaModePostgresPvc: Resource[corev1.PersistentVolumeClaim]{
 			ID: "PersistentVolumeClaim/" + fullName + "-postgres",

--- a/charts/control-plane/test/config_test.go
+++ b/charts/control-plane/test/config_test.go
@@ -48,14 +48,12 @@ singleReplicaMode:
 	expected.Deployment.Value.Spec.Replicas = &two
 
 	pts := &expected.Deployment.Value.Spec.Template.Spec
-	pts.Volumes = append(pts.Volumes[:2], pts.Volumes[4:]...)
-	pts.Volumes[1].PersistentVolumeClaim = nil
-	pts.Volumes[1].EmptyDir = &corev1.EmptyDirVolumeSource{}
+	pts.Volumes = append(pts.Volumes[:2], pts.Volumes[5:]...)
 
 	ctr := &pts.Containers[0]
-	ctr.VolumeMounts = append(ctr.VolumeMounts[:2], ctr.VolumeMounts[4:]...)
+	ctr.VolumeMounts = append(ctr.VolumeMounts[:2], ctr.VolumeMounts[5:]...)
 
-	expected.SingleReplicaModeDataPvc.HasValue = false
+	expected.SingleReplicaModeEncryptionPvc.HasValue = false
 	expected.SingleReplicaModePostgresPvc.HasValue = false
 	expected.SingleReplicaModePrometheusPvc.HasValue = false
 
@@ -249,15 +247,13 @@ singleReplicaMode:
 			expected.Deployment.Value.Spec.Strategy = appsv1.DeploymentStrategy{}
 
 			pts := &expected.Deployment.Value.Spec.Template.Spec
-			pts.Volumes = append(pts.Volumes[:2], pts.Volumes[4:]...)
-			pts.Volumes[1].PersistentVolumeClaim = nil
-			pts.Volumes[1].EmptyDir = &corev1.EmptyDirVolumeSource{}
+			pts.Volumes = append(pts.Volumes[:2], pts.Volumes[5:]...)
 
 			ctr := &pts.Containers[0]
-			ctr.VolumeMounts = append(ctr.VolumeMounts[:2], ctr.VolumeMounts[4:]...)
+			ctr.VolumeMounts = append(ctr.VolumeMounts[:2], ctr.VolumeMounts[5:]...)
 			ctr.VolumeMounts[1].MountPath = "/mnt/data"
 
-			expected.SingleReplicaModeDataPvc.HasValue = false
+			expected.SingleReplicaModeEncryptionPvc.HasValue = false
 			expected.SingleReplicaModePostgresPvc.HasValue = false
 			expected.SingleReplicaModePrometheusPvc.HasValue = false
 

--- a/charts/control-plane/test/defaults_test.go
+++ b/charts/control-plane/test/defaults_test.go
@@ -181,6 +181,10 @@ func DefaultResources(t *testing.T, test *Test) *Resources {
 											Name:      "data",
 										},
 										{
+											MountPath: "/data/encryption",
+											Name:      "encryption",
+										},
+										{
 											MountPath: "/data/postgres",
 											Name:      "postgres",
 										},
@@ -213,8 +217,14 @@ func DefaultResources(t *testing.T, test *Test) *Resources {
 								{
 									Name: "data",
 									VolumeSource: corev1.VolumeSource{
+										EmptyDir: &corev1.EmptyDirVolumeSource{},
+									},
+								},
+								{
+									Name: "encryption",
+									VolumeSource: corev1.VolumeSource{
 										PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-											ClaimName: "control-plane-data",
+											ClaimName: "control-plane-encryption",
 										},
 									},
 								},
@@ -336,7 +346,7 @@ func DefaultResources(t *testing.T, test *Test) *Resources {
 				},
 			},
 		},
-		SingleReplicaModeDataPvc: Resource[corev1.PersistentVolumeClaim]{
+		SingleReplicaModeEncryptionPvc: Resource[corev1.PersistentVolumeClaim]{
 			ID:       dr.ServiceAccount.ID,
 			HasValue: true,
 			Value: corev1.PersistentVolumeClaim{
@@ -345,7 +355,7 @@ func DefaultResources(t *testing.T, test *Test) *Resources {
 					APIVersion: "v1",
 				},
 				ObjectMeta: v1.ObjectMeta{
-					Name:   fullName + "-data",
+					Name:   fullName + "-encryption",
 					Labels: cpLabels(),
 				},
 				Spec: corev1.PersistentVolumeClaimSpec{

--- a/charts/control-plane/test/resources_test.go
+++ b/charts/control-plane/test/resources_test.go
@@ -30,7 +30,7 @@ imagePullSecret:
 		&expected.Deployment.Value.ObjectMeta,
 		&expected.Deployment.Value.Spec.Template.ObjectMeta,
 		&expected.Service.Value.ObjectMeta,
-		&expected.SingleReplicaModeDataPvc.Value.ObjectMeta,
+		&expected.SingleReplicaModeEncryptionPvc.Value.ObjectMeta,
 		&expected.SingleReplicaModePostgresPvc.Value.ObjectMeta,
 		&expected.SingleReplicaModePrometheusPvc.Value.ObjectMeta,
 	}
@@ -181,7 +181,7 @@ serviceAccount:
       labels:
         test: test
 singleReplicaMode:
-  dataPvc:
+  encryptionPvc:
     merge:
       metadata:
         labels:
@@ -224,7 +224,7 @@ serviceAccount:
   enabled: true
   patch: [{op: add, path: /metadata/labels/test, value: test}]
 singleReplicaMode:
-  dataPvc:
+  encryptionPvc:
     patch: [{op: add, path: /metadata/labels/test, value: test}]
   postgresPvc:
     patch: [{op: add, path: /metadata/labels/test, value: test}]
@@ -247,7 +247,7 @@ singleReplicaMode:
 				&expected.ImagePullSecret.Value.ObjectMeta,
 				&expected.Service.Value.ObjectMeta,
 				&expected.ServiceAccount.Value.ObjectMeta,
-				&expected.SingleReplicaModeDataPvc.Value.ObjectMeta,
+				&expected.SingleReplicaModeEncryptionPvc.Value.ObjectMeta,
 				&expected.SingleReplicaModePostgresPvc.Value.ObjectMeta,
 				&expected.SingleReplicaModePrometheusPvc.Value.ObjectMeta,
 			}

--- a/charts/control-plane/values.yaml
+++ b/charts/control-plane/values.yaml
@@ -303,10 +303,10 @@ singleReplicaMode:
   enabled: true
 
   ############################################################
-  # data pvc
+  # encryption pvc
   ############################################################
-  # will be mounted if config.kms is not enabled
-  dataPvc:
+  # should be enabled when config.kms.key is not configured
+  encryptionPvc:
     # enable/disable creation of the PVC
     # WARNING: changing this to false after the PVC is created will result in the PVC being deleted
     enabled: true
@@ -318,13 +318,13 @@ singleReplicaMode:
     # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#persistentvolumeclaim-v1-core
     merge: {}
     patch: []
-    # defaults to "{{ include "scp.fullname" $ }}-data"
+    # defaults to "{{ include "scp.fullname" $ }}-encryption"
     name:
 
   ############################################################
   # postgres pvc
   ############################################################
-  # will be mounted if config.dataSources.postgres is not enabled
+  # should be enabled when config.dataSources.postgres is not configured
   postgresPvc:
     # enable/disable creation of the PVC
     # WARNING: changing this to false after the PVC is created will result in the PVC being deleted
@@ -343,7 +343,7 @@ singleReplicaMode:
   ############################################################
   # prometheus pvc
   ############################################################
-  # will be enabled if config.dataSources.prometheus is not enabled
+  # should be enabled when config.dataSources.prometheus is not configured
   prometheusPvc:
     # enable/disable creation of the PVC
     # WARNING: changing this to false after the PVC is created will result in the PVC being deleted


### PR DESCRIPTION
Since `/data` is a bit of a scratch directory, it doesn't feel right putting a 1GiB PVC volume there.  May need to end up storing larger ephemeral data here, so `emptyDir` seems best...

Moves the `dataPvc` to `encryptionPvc` which is mounted to `/data/encryption` now

Also did a pass at updating the README in prep to get synced over to the docs repo